### PR TITLE
fix: update render-table workflow to tag with pr/tooling

### DIFF
--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -25,5 +25,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update RFC table in README
+          label: pr/tooling
           title: Update RFC table in README
           branch: auto/update-rfc-table


### PR DESCRIPTION
Make it s.t. automatic PR's from gh bot only requires 1 approve

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license_
